### PR TITLE
Use wc_price() to echo price in correct format.

### DIFF
--- a/sales-by-country.php
+++ b/sales-by-country.php
@@ -106,7 +106,7 @@ if ( is_plugin_active( 'woocommerce/woocommerce.php' ) ) :
                 <?php foreach ( $wsc->get_country_sales() as $view ) : ?>
                     <tr>
                         <td><?php echo $wsc->country_name( $view->country_name ); ?></td>
-                        <td><?php echo get_woocommerce_currency_symbol() . round( $view->sale_total, 2 ); ?></td>
+                        <td><?php echo wc_price($view->sale_total); ?></td>
                     </tr>
                 <?php endforeach; ?>
                 </tbody>


### PR DESCRIPTION
Use WooCommerce function to generate price. The resulting number will use the WooCommerce Currency Options settings, including currency symbol, thousands separator, decimal separator and number of decimals. Current method often had only 1 decimal eg. 12.1 instead of 12.10.
